### PR TITLE
avoid dynamic requires to enable browserify support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
-var path = require('path')
-
 module.exports = {
-  rules: require('requireindex')(path.resolve(__dirname, 'rules')),
+  rules: {
+    'array-bracket-even-spacing': require('./rules/array-bracket-even-spacing.js'),
+    'computed-property-even-spacing': require('./rules/computed-property-even-spacing.js'),
+    'object-curly-even-spacing': require('./rules/object-curly-even-spacing.js')
+  },
   rulesConfig: {
     'object-curly-even-spacing': 0,
     'array-bracket-even-spacing': 0,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,5 @@
     "eslint": "^1.0.0"
   },
   "dependencies": {
-    "requireindex": "^1.1.0"
   }
 }


### PR DESCRIPTION
Hello!

I'm building out a web tool to validate code using `standard` rules, and I ran into some issues with this package. 

Switching the rules definition to be less dynamic enables this package to be more easily browserify-able.

Is this OK?