### PR TITLE
Add a linter rule which disallows parens around single argument arrow functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ ESlint Rules for the Standard Linter
   rules: {
     'standard/object-curly-even-spacing': [2, "either"]
     'standard/array-bracket-even-spacing': [2, "either"],
-    'standard/computed-property-even-spacing': [2, "even"]
+    'standard/computed-property-even-spacing': [2, "even"],
+    'standard/arrow-function-parens': [2]
   }
 }
 ```
@@ -24,4 +25,6 @@ There are several rules that were created specifically for the `standard` linter
 - `object-curly-even-spacing` - Like `object-curly-spacing` from ESLint except it has an `either` option which lets you have 1 or 0 spaces padding.
 - `array-bracket-even-spacing` - Like `array-bracket-even-spacing` from ESLint except it has an `either` option which lets you have 1 or 0 spacing padding.
 - `computed-property-even-spacing` - Like `computed-property-spacing` around ESLint except is has an `even` option which lets you have 1 or 0 spacing padding.
+- `arrow-function-parens` - Does not allow parens around single arguments in arrow functions.
+
 

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@
 module.exports = {
   rules: {
     'array-bracket-even-spacing': require('./rules/array-bracket-even-spacing.js'),
+    'arrow-function-parens': require('./rules/arrow-function-parens.js'),
     'computed-property-even-spacing': require('./rules/computed-property-even-spacing.js'),
     'object-curly-even-spacing': require('./rules/object-curly-even-spacing.js')
   },
   rulesConfig: {
     'object-curly-even-spacing': 0,
     'array-bracket-even-spacing': 0,
-    'computed-property-even-spacing': 0
+    'computed-property-even-spacing': 0,
+    'arrow-function-parens': 0
   }
 }

--- a/rules/arrow-function-parens.js
+++ b/rules/arrow-function-parens.js
@@ -1,0 +1,24 @@
+module.exports = function (context) {
+  var message = 'arrow function with a single argument should not be wrapped in parens'
+
+  function arrowFunctionParens (node) {
+    var token = context.getFirstToken(node)
+    var numIdentifiers = 0
+    while (true) {
+      if (token.type === 'Identifier') {
+        numIdentifiers++
+      } else if (token.value !== '(' && token.value !== ',') {
+        break
+      }
+      token = context.getTokenAfter(token)
+    }
+
+    if (numIdentifiers === 1 && token.value !== '=>') {
+      context.report(node, message)
+    }
+  }
+
+  return {
+    ArrowFunctionExpression: arrowFunctionParens
+  }
+}

--- a/tests/arrow-function-parens.js
+++ b/tests/arrow-function-parens.js
@@ -1,0 +1,33 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/arrow-function-parens')
+
+var valid = [
+  'a.then(foo => {});',
+  'a.then(foo => a);',
+  'a.then((foo, bar) => {});',
+  'a.then((foo, bar) => a);'
+].map(function (code) {
+  return {
+    code: code,
+    ecmaFeatures: { arrowFunctions: true }
+  }
+})
+
+var message = 'arrow function with a single argument should not be wrapped in parens'
+
+var invalid = [
+  'a.then((foo) => {});',
+  'a.then((foo) => { if (true) {}; });'
+].map(function (code) {
+  return {
+    code: code,
+    ecmaFeatures: { arrowFunctions: true },
+    errors: [{ message: message }]
+  }
+})
+
+var ruleTester = new RuleTester()
+ruleTester.run('arrow-function-parens', rule, {
+  valid: valid,
+  invalid: invalid
+})


### PR DESCRIPTION
This is the plugin implementation work for: https://github.com/feross/standard/issues/309