### PR TITLE
New Rule: no-callback-literal (fixes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ESlint Rules for the Standard Linter
     'standard/object-curly-even-spacing': [2, "either"]
     'standard/array-bracket-even-spacing': [2, "either"],
     'standard/computed-property-even-spacing': [2, "even"]
+    'standard/no-callback-literal': [2, ["cb", "callback", "next"]]
   }
 }
 ```
@@ -24,4 +25,5 @@ There are several rules that were created specifically for the `standard` linter
 - `object-curly-even-spacing` - Like `object-curly-spacing` from ESLint except it has an `either` option which lets you have 1 or 0 spaces padding.
 - `array-bracket-even-spacing` - Like `array-bracket-even-spacing` from ESLint except it has an `either` option which lets you have 1 or 0 spacing padding.
 - `computed-property-even-spacing` - Like `computed-property-spacing` around ESLint except is has an `even` option which lets you have 1 or 0 spacing padding.
+- `no-callback-literal` - Ensures that we strictly follow the callback pattern with `undefined`, `false`, `null` or an error object in the first position of a callback.
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@ module.exports = {
   rules: {
     'array-bracket-even-spacing': require('./rules/array-bracket-even-spacing.js'),
     'computed-property-even-spacing': require('./rules/computed-property-even-spacing.js'),
-    'object-curly-even-spacing': require('./rules/object-curly-even-spacing.js')
+    'object-curly-even-spacing': require('./rules/object-curly-even-spacing.js'),
+    'no-callback-literal': require('./rules/no-callback-literal.js')
   },
   rulesConfig: {
     'object-curly-even-spacing': 0,
     'array-bracket-even-spacing': 0,
-    'computed-property-even-spacing': 0
+    'computed-property-even-spacing': 0,
+    'no-callback-literal': 0
   }
 }

--- a/rules/no-callback-literal.js
+++ b/rules/no-callback-literal.js
@@ -1,0 +1,77 @@
+/**
+ * Ensures that the callback pattern is followed properly
+ * with an Error object (or undefined or null) in the first position.
+ */
+
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+/**
+ * Determine if a node has a possiblity to be an Error object
+ * @param  {ASTNode}  node  ASTNode to check
+ * @returns {boolean}       True if there is a chance it contains an Error obj
+ */
+function couldBeError (node) {
+  switch (node.type) {
+    case 'Identifier':
+    case 'CallExpression':
+    case 'NewExpression':
+    case 'MemberExpression':
+    case 'TaggedTemplateExpression':
+    case 'YieldExpression':
+      return true // possibly an error object.
+
+    case 'AssignmentExpression':
+      return couldBeError(node.right)
+
+    case 'SequenceExpression':
+      var exprs = node.expressions
+      return exprs.length !== 0 && couldBeError(exprs[exprs.length - 1])
+
+    case 'LogicalExpression':
+      return couldBeError(node.left) || couldBeError(node.right)
+
+    case 'ConditionalExpression':
+      return couldBeError(node.consequent) || couldBeError(node.alternate)
+
+    default:
+      return node.value === null || node.value === false
+  }
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {}
+  },
+
+  create: function (context) {
+    var callbackNames = context.options[0] || ['callback', 'next', 'cb']
+
+    function isCallback (name) {
+      return callbackNames.indexOf(name) > -1
+    }
+
+    return {
+
+      CallExpression: function (node) {
+        var errorArg = node.arguments[0]
+        if (errorArg && isCallback(node.callee.name)) {
+          if (!couldBeError(errorArg)) {
+            context.report(node, 'Unexpected literal in error position of callback.')
+          } else if (node.arguments.length > 1 && errorArg.type === 'Identifier') {
+            if (errorArg.name === 'undefined') {
+              context.report(node, 'Expected null instead found undefined.')
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/no-callback-literal.js
+++ b/tests/no-callback-literal.js
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Tests for the no-callback-literal rule
+ * @author Jamund Ferguson
+ * @copyright 2016 Jamund Ferguson. All rights reserved.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/no-callback-literal')
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester()
+ruleTester.run('no-callback-literal', rule, {
+  valid: [
+
+    // random stuff
+    'horse()',
+    'sort(null)',
+    'require("zyx")',
+    'require("zyx", data)',
+
+    // callback()
+    'callback()',
+    'callback(undefined)',
+    'callback(null)',
+    'callback(x)',
+    'callback(false)',
+    'callback(new Error("error"))',
+    'callback(friendly, data)',
+    'callback(null, data)',
+    'callback(x, data)',
+    'callback(new Error("error"), data)',
+
+    // cb()
+    'cb()',
+    'cb(false)',
+    'cb(undefined)',
+    'cb(null)',
+    'cb(null, "super")',
+
+    // next()
+    'next()',
+    'next(undefined)',
+    'next(null)',
+    'next(null, "super")',
+    'next(false, "super")',
+
+    // custom callback
+    {
+      code: 'callback(44); next("55"); power(new Error("super thing")); power(null);',
+      options: [['power']]
+    }
+  ],
+
+  invalid: [
+    // callback
+    { code: 'callback(undefined, "snork")', errors: [{ message: 'Expected null instead found undefined.' }] },
+    { code: 'callback("help")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
+    { code: 'callback("help", data)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
+
+    // cb
+    { code: 'cb(undefined, "snork")', errors: [{ message: 'Expected null instead found undefined.' }] },
+    { code: 'cb("help")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
+    { code: 'cb("help", data)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
+
+    // next
+    { code: 'next(undefined, "snork")', errors: [{ message: 'Expected null instead found undefined.' }] },
+    { code: 'next("help")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
+    { code: 'next("help", data)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
+
+    // custom callback name
+    {
+      code: 'nexty(44)',
+      options: [['nexty']],
+      errors: [{ message: 'Unexpected literal in error position of callback.' }]
+    }
+  ]
+})


### PR DESCRIPTION
Tries to more strictly enforce the callback pattern. This will help people avoid the common mistake of calling back with an error message instead of an error object, which can lead to all sorts of weird bugs.

There is already this similar rule in ESLint:
http://eslint.org/docs/rules/no-throw-literal

There are probably some async patterns out there that this will wreck, so we need to test it with more than just my code base :)
