### PR TITLE
Don't allow `false` in "no-callback-literal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ There are several rules that were created specifically for the `standard` linter
 - `object-curly-even-spacing` - Like `object-curly-spacing` from ESLint except it has an `either` option which lets you have 1 or 0 spaces padding.
 - `array-bracket-even-spacing` - Like `array-bracket-even-spacing` from ESLint except it has an `either` option which lets you have 1 or 0 spacing padding.
 - `computed-property-even-spacing` - Like `computed-property-spacing` around ESLint except is has an `even` option which lets you have 1 or 0 spacing padding.
-- `no-callback-literal` - Ensures that we strictly follow the callback pattern with `undefined`, `false`, `null` or an error object in the first position of a callback.
+- `no-callback-literal` - Ensures that we strictly follow the callback pattern with `undefined`, `null` or an error object in the first position of a callback.
 

--- a/rules/no-callback-literal.js
+++ b/rules/no-callback-literal.js
@@ -38,7 +38,7 @@ function couldBeError (node) {
       return couldBeError(node.consequent) || couldBeError(node.alternate)
 
     default:
-      return node.value === null || node.value === false
+      return node.value === null
   }
 }
 
@@ -67,7 +67,7 @@ module.exports = {
             context.report(node, 'Unexpected literal in error position of callback.')
           } else if (node.arguments.length > 1 && errorArg.type === 'Identifier') {
             if (errorArg.name === 'undefined') {
-              context.report(node, 'Expected null instead found undefined.')
+              context.report(node, 'Expected "null" instead of "undefined" in error position of callback.')
             }
           }
         }

--- a/tests/no-callback-literal.js
+++ b/tests/no-callback-literal.js
@@ -31,7 +31,6 @@ ruleTester.run('no-callback-literal', rule, {
     'callback(undefined)',
     'callback(null)',
     'callback(x)',
-    'callback(false)',
     'callback(new Error("error"))',
     'callback(friendly, data)',
     'callback(null, data)',
@@ -40,7 +39,6 @@ ruleTester.run('no-callback-literal', rule, {
 
     // cb()
     'cb()',
-    'cb(false)',
     'cb(undefined)',
     'cb(null)',
     'cb(null, "super")',
@@ -50,7 +48,6 @@ ruleTester.run('no-callback-literal', rule, {
     'next(undefined)',
     'next(null)',
     'next(null, "super")',
-    'next(false, "super")',
 
     // custom callback
     {
@@ -61,17 +58,20 @@ ruleTester.run('no-callback-literal', rule, {
 
   invalid: [
     // callback
-    { code: 'callback(undefined, "snork")', errors: [{ message: 'Expected null instead found undefined.' }] },
+    { code: 'callback(undefined, "snork")', errors: [{ message: 'Expected "null" instead of "undefined" in error position of callback.' }] },
+    { code: 'callback(false, "snork")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
     { code: 'callback("help")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
     { code: 'callback("help", data)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
 
     // cb
-    { code: 'cb(undefined, "snork")', errors: [{ message: 'Expected null instead found undefined.' }] },
+    { code: 'cb(undefined, "snork")', errors: [{ message: 'Expected "null" instead of "undefined" in error position of callback.' }] },
+    { code: 'cb(false)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
     { code: 'cb("help")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
     { code: 'cb("help", data)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
 
     // next
-    { code: 'next(undefined, "snork")', errors: [{ message: 'Expected null instead found undefined.' }] },
+    { code: 'next(undefined, "snork")', errors: [{ message: 'Expected "null" instead of "undefined" in error position of callback.' }] },
+    { code: 'next(false, "snork")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
     { code: 'next("help")', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
     { code: 'next("help", data)', errors: [{ message: 'Unexpected literal in error position of callback.' }] },
 


### PR DESCRIPTION
There was discussion about not allowing `false` for this rule, and I think that's what the consensus was. https://github.com/xjamundx/eslint-plugin-standard/pull/15