### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/rules/array-bracket-even-spacing.js
+++ b/rules/array-bracket-even-spacing.js
@@ -14,7 +14,9 @@
 
 module.exports = {
   meta: {
-    docs: {}
+    docs: {
+      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+    }
   },
 
   create: function (context) {

--- a/rules/computed-property-even-spacing.js
+++ b/rules/computed-property-even-spacing.js
@@ -11,7 +11,9 @@
 
 module.exports = {
   meta: {
-    docs: {}
+    docs: {
+      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+    }
   },
 
   create: function (context) {

--- a/rules/no-callback-literal.js
+++ b/rules/no-callback-literal.js
@@ -48,7 +48,9 @@ function couldBeError (node) {
 
 module.exports = {
   meta: {
-    docs: {}
+    docs: {
+      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+    }
   },
 
   create: function (context) {

--- a/rules/object-curly-even-spacing.js
+++ b/rules/object-curly-even-spacing.js
@@ -14,7 +14,9 @@
 
 module.exports = {
   meta: {
-    docs: {}
+    docs: {
+      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+    }
   },
 
   create: function (context) {


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.

_Note: I realize the URL is all the same, but it seems there is no individual documentation for these rules._